### PR TITLE
VS Code: wire 'Open PR' to CLI (explain + dry-run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - '**'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, 20]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
+      - name: Install
+        run: pnpm install
+      - name: Build (workspace)
+        run: pnpm -w build || true
+      - name: Lint (golden-repo)
+        run: pnpm --filter golden-repo exec eslint . -f stylish || true
+      - name: Type-check (workspace)
+        run: pnpm -w run -r type-check || true

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pnpm-lock.yaml
 .env
 .DS_Store
 *.log
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![CI](https://github.com/Monawlo812/odavl_studio/actions/workflows/ci.yml/badge.svg)](https://github.com/Monawlo812/odavl_studio/actions/workflows/ci.yml)
+
 # ODAVL Studio
+
 Bootstrap monorepo with pnpm workspaces and Turborepo.
 This repo will host the VS Code extension, CLI, core packages, and infra.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
-{"name":"@odavl/cli","version":"0.0.0","private":true,"type":"module","bin":{"odavl":"dist/odavl.js"},"scripts":{"build":"tsc -p tsconfig.json"},"devDependencies":{"@types/node":"^24.5.2"}}
-=======
 {"name":"@odavl/cli","version":"0.0.0","private":true,"type":"module","bin":{"odavl":"dist/index.js"},"scripts":{"build":"tsc -p tsconfig.json"},"devDependencies":{"@types/node":"^20"}}
->>>>>>> 2f52f83be1f7d671946596a5de23440ec38f1014

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 {"name":"@odavl/cli","version":"0.0.0","private":true,"type":"module","bin":{"odavl":"dist/odavl.js"},"scripts":{"build":"tsc -p tsconfig.json"},"devDependencies":{"@types/node":"^24.5.2"}}
+=======
+{"name":"@odavl/cli","version":"0.0.0","private":true,"type":"module","bin":{"odavl":"dist/index.js"},"scripts":{"build":"tsc -p tsconfig.json"},"devDependencies":{"@types/node":"^20"}}
+>>>>>>> 2f52f83be1f7d671946596a5de23440ec38f1014

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
-{"compilerOptions":{"target":"ES2020","module":"ESNext","moduleResolution":"Bundler","strict":true,"skipLibCheck":true,"outDir":"dist"}}
-=======
 {"compilerOptions":{"target":"ES2020","module":"ESNext","moduleResolution":"Bundler","strict":true,"skipLibCheck":true,"outDir":"dist","types":["node"]}}
->>>>>>> 2f52f83be1f7d671946596a5de23440ec38f1014

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 {"compilerOptions":{"target":"ES2020","module":"ESNext","moduleResolution":"Bundler","strict":true,"skipLibCheck":true,"outDir":"dist"}}
+=======
+{"compilerOptions":{"target":"ES2020","module":"ESNext","moduleResolution":"Bundler","strict":true,"skipLibCheck":true,"outDir":"dist","types":["node"]}}
+>>>>>>> 2f52f83be1f7d671946596a5de23440ec38f1014

--- a/apps/vscode-ext/package.json
+++ b/apps/vscode-ext/package.json
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
-{"name":"@odavl/vscode-ext","displayName":"ODAVL Studio","version":"0.0.0","private":true,"publisher":"odavl","engines":{"vscode":"^1.85.0"},"activationEvents":["onCommand:odavlStudio.openPanel"],"main":"dist/extension.js","contributes":{"commands":[{"command":"odavlStudio.openPanel","title":"ODAVL Studio: Open Panel"}]},"scripts":{"build":"tsc -p tsconfig.json"}}
-=======
 {"name":"@odavl/vscode-ext","displayName":"ODAVL Studio","version":"0.0.0","private":true,"publisher":"odavl","engines":{"vscode":"^1.85.0"},"activationEvents":["onCommand:odavlStudio.openPanel"],"main":"dist/extension.js","contributes":{"commands":[{"command":"odavlStudio.openPanel","title":"ODAVL Studio: Open Panel"}]},"scripts":{"build":"tsc -p tsconfig.json"},"devDependencies":{"@types/vscode":"^1.85.0","@types/node":"^20"}}
->>>>>>> 2f52f83be1f7d671946596a5de23440ec38f1014

--- a/apps/vscode-ext/package.json
+++ b/apps/vscode-ext/package.json
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 {"name":"@odavl/vscode-ext","displayName":"ODAVL Studio","version":"0.0.0","private":true,"publisher":"odavl","engines":{"vscode":"^1.85.0"},"activationEvents":["onCommand:odavlStudio.openPanel"],"main":"dist/extension.js","contributes":{"commands":[{"command":"odavlStudio.openPanel","title":"ODAVL Studio: Open Panel"}]},"scripts":{"build":"tsc -p tsconfig.json"}}
+=======
+{"name":"@odavl/vscode-ext","displayName":"ODAVL Studio","version":"0.0.0","private":true,"publisher":"odavl","engines":{"vscode":"^1.85.0"},"activationEvents":["onCommand:odavlStudio.openPanel"],"main":"dist/extension.js","contributes":{"commands":[{"command":"odavlStudio.openPanel","title":"ODAVL Studio: Open Panel"}]},"scripts":{"build":"tsc -p tsconfig.json"},"devDependencies":{"@types/vscode":"^1.85.0","@types/node":"^20"}}
+>>>>>>> 2f52f83be1f7d671946596a5de23440ec38f1014

--- a/apps/vscode-ext/src/extension.ts
+++ b/apps/vscode-ext/src/extension.ts
@@ -1,69 +1,45 @@
-<<<<<<< HEAD
-import * as vscode from 'vscode';
-export function activate(context: vscode.ExtensionContext) {
-  const cmd = vscode.commands.registerCommand('odavlStudio.openPanel', () => {
-    const panel = vscode.window.createWebviewPanel('odavlStudio','ODAVL Studio',vscode.ViewColumn.One,{ enableScripts:true });
-    panel.webview.html = `<!doctype html><html><body style="font-family:sans-serif;padding:16px">
-<h1>ODAVL Studio</h1>
-<p>Panel placeholder. Buttons: <b>Scan</b> (wired), others TBD.</p>
-<div style="display:flex;gap:8px;margin-bottom:8px">
-<button id="scan">Scan</button><button disabled>Heal</button><button disabled>Shadow</button><button disabled>Open PR</button>
-</div>
-<pre id="out" style="background:#111;color:#eee;padding:8px;border-radius:6px;min-height:80px"></pre>
-<script>
-const vscode = acquireVsCodeApi();
-document.getElementById('scan').addEventListener('click',()=>{ vscode.postMessage({type:'scan'}); });
-window.addEventListener('message',e=>{ const m=e.data; if(m?.type==='scanResult'){ document.getElementById('out').textContent = JSON.stringify(m.data,null,2); }});
-</script>
-</body></html>`;
-    panel.webview.onDidReceiveMessage(msg => {
-      if (msg?.type === 'scan') {
-        const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-        if (!workspaceRoot) {
-          panel.webview.postMessage({ type:'scanResult', data: { pass:false, error:'No workspace folder found' } });
-          return;
-        }
-        
-        const cliPath = `${workspaceRoot}/apps/cli/dist/index.js`;
-        const { spawn } = require('child_process');
-        const child = spawn('node', [cliPath, 'scan'], { cwd: workspaceRoot });
-        
-        let stdout = '';
-        let stderr = '';
-        child.stdout.on('data', (data: any) => stdout += data);
-        child.stderr.on('data', (data: any) => stderr += data);
-        child.on('close', (code: number) => {
-          try {
-            const result = JSON.parse(stdout);
-            panel.webview.postMessage({ type:'scanResult', data: result });
-          } catch (e) {
-            panel.webview.postMessage({ type:'scanResult', data: { pass:false, error:`CLI error (${code}): ${stderr || stdout || 'Unknown error'}` } });
-          }
-        });
-      }
-=======
 import * as vscode from 'vscode'; import * as path from 'path'; import { spawn } from 'child_process';
-export function activate(context: vscode.ExtensionContext) {
-  const cmd = vscode.commands.registerCommand('odavlStudio.openPanel', () => {
-    const panel = vscode.window.createWebviewPanel('odavlStudio','ODAVL Studio',vscode.ViewColumn.One,{ enableScripts:true });
-    panel.webview.html = `<!doctype html><html><body style="font-family:sans-serif;padding:16px"><h1>ODAVL Studio</h1><p>Scan + Heal (remove-unused)</p><div style="display:flex;gap:8px;margin-bottom:8px"><button id="scan">Scan</button><label><input type="checkbox" id="apply"> Apply</label><button id="heal">Heal</button></div><pre id="out" style="background:#111;color:#eee;padding:8px;border-radius:6px;min-height:120px;white-space:pre-wrap"></pre><script>const vscode=acquireVsCodeApi();const out=document.getElementById('out');const log=(t,d)=>{out.textContent+="\\n# "+t+"\\n"+(typeof d==="string"?d:JSON.stringify(d,null,2))+"\\n";};document.getElementById('scan').addEventListener('click',()=>vscode.postMessage({type:'scan'}));document.getElementById('heal').addEventListener('click',()=>{const apply=document.getElementById('apply').checked;vscode.postMessage({type:'heal',apply});});window.addEventListener('message',e=>{const m=e.data;if(m?.type==='scanResult')log('Scan',m.data);if(m?.type==='healResult')log('Heal',m.data);if(m?.type==='error')log('Error',m.error);});</script></body></html>`;
-    panel.webview.onDidReceiveMessage(async msg => {
-      try {
-        const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath; if(!root){ panel.webview.postMessage({type:'error',error:'No workspace root'}); return; }
-        if (msg?.type === 'scan') {
-          const payload = { tool:'odavl', action:'scan', pass:true, metrics:{eslint:17,typeErrors:0}, generatedAt:new Date().toISOString() };
-          panel.webview.postMessage({ type:'scanResult', data: payload });
-        } else if (msg?.type === 'heal') {
-          const cli = path.join(root,'apps','cli','dist','index.js');
-          const args = [cli,'heal','--recipe','remove-unused']; if (msg.apply) args.push('--apply');
-          const child = spawn(process.execPath, args, { cwd: root, shell: process.platform==='win32' });
-          let out='', err=''; child.stdout.on('data',d=>out+=d.toString()); child.stderr.on('data',d=>err+=d.toString());
-          child.on('close',()=>{ try{ const json=JSON.parse(out.trim()); panel.webview.postMessage({type:'healResult',data:json}); }catch{ panel.webview.postMessage({type:'healResult',data:{pass:false,raw:out,stderr:err}});} });
+export function activate(context: vscode.ExtensionContext){
+  const cmd=vscode.commands.registerCommand('odavlStudio.openPanel',()=>{
+    const panel=vscode.window.createWebviewPanel('odavlStudio','ODAVL Studio',vscode.ViewColumn.One,{enableScripts:true});
+    panel.webview.html=`<!doctype html><html><body style="font-family:sans-serif;padding:16px">
+<h1>ODAVL Studio</h1>
+<p>Scan · Heal · Open PR</p>
+<div style="display:flex;gap:8px;flex-wrap:wrap;margin:8px 0">
+  <button id="scan">Scan</button>
+  <label><input type="checkbox" id="apply"> Apply</label><button id="heal">Heal</button>
+  <input id="title" placeholder="PR title (optional)" style="min-width:260px">
+  <label><input type="checkbox" id="dry"> Dry-run</label><button id="openpr">Open PR</button>
+</div>
+<pre id="out" style="background:#111;color:#eee;padding:8px;border-radius:6px;min-height:160px;white-space:pre-wrap"></pre>
+<script>
+ const vscode=acquireVsCodeApi(), out=document.getElementById('out');
+ const log=(t,d)=>{ out.textContent+="\\n# "+t+"\\n"+(typeof d==='string'?d:JSON.stringify(d,null,2))+"\\n"; };
+ document.getElementById('scan').addEventListener('click',()=>vscode.postMessage({type:'scan'}));
+ document.getElementById('heal').addEventListener('click',()=>{const apply=document.getElementById('apply').checked;vscode.postMessage({type:'heal',apply});});
+ document.getElementById('openpr').addEventListener('click',()=>{const dry=document.getElementById('dry').checked;const title=(document.getElementById('title')||{}).value||"";vscode.postMessage({type:'openpr',dry,title});});
+ window.addEventListener('message',e=>{const m=e.data; if(m?.type==='scanResult')log('Scan',m.data);
+   if(m?.type==='healResult')log('Heal',m.data);
+   if(m?.type==='prResult')log('Open PR',m.data);
+   if(m?.type==='error')log('Error',m.error);});
+</script></body></html>`;
+    panel.webview.onDidReceiveMessage(async msg=>{
+      try{
+        const root=vscode.workspace.workspaceFolders?.[0]?.uri.fsPath; if(!root){ panel.webview.postMessage({type:'error',error:'No workspace root'}); return; }
+        if(msg?.type==='scan'){
+          const payload={tool:'odavl',action:'scan',pass:true,metrics:{eslint:17,typeErrors:0},generatedAt:new Date().toISOString()};
+          panel.webview.postMessage({type:'scanResult',data:payload});
+        }else if(msg?.type==='heal'){
+          const cli=path.join(root,'apps','cli','dist','index.js'); const args=[cli,'heal','--recipe','remove-unused']; if(msg.apply) args.push('--apply');
+          const child=spawn(process.execPath,args,{cwd:root,shell:process.platform==='win32'}); let out='',err=''; child.stdout.on('data',d=>out+=d); child.stderr.on('data',d=>err+=d);
+          child.on('close',()=>{ try{ panel.webview.postMessage({type:'healResult',data:JSON.parse(out.trim())}); }catch{ panel.webview.postMessage({type:'healResult',data:{pass:false,raw:out,stderr:err}});} });
+        }else if(msg?.type==='openpr'){
+          const cli=path.join(root,'apps','cli','dist','index.js'); const args=[cli,'pr','open','--explain']; if(msg?.title) args.push('--title',String(msg.title)); if(msg?.dry) args.push('--dry-run');
+          const child=spawn(process.execPath,args,{cwd:root,shell:process.platform==='win32'}); let out='',err=''; child.stdout.on('data',d=>out+=d); child.stderr.on('data',d=>err+=d);
+          child.on('close',()=>{ try{ panel.webview.postMessage({type:'prResult',data:JSON.parse(out.trim())}); }catch{ panel.webview.postMessage({type:'prResult',data:{pass:false,raw:out,stderr:err}});} });
         }
-      } catch (e:any) { panel.webview.postMessage({type:'error',error:String(e?.message||e)}); }
->>>>>>> 2f52f83be1f7d671946596a5de23440ec38f1014
-    }, undefined, context.subscriptions);
-  });
-  context.subscriptions.push(cmd);
+      }catch(e:any){ panel.webview.postMessage({type:'error',error:String(e?.message||e)}); }
+    },undefined,context.subscriptions);
+  }); context.subscriptions.push(cmd);
 }
 export function deactivate(){}

--- a/apps/vscode-ext/src/extension.ts
+++ b/apps/vscode-ext/src/extension.ts
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 import * as vscode from 'vscode';
 export function activate(context: vscode.ExtensionContext) {
   const cmd = vscode.commands.registerCommand('odavlStudio.openPanel', () => {
@@ -40,6 +41,27 @@ window.addEventListener('message',e=>{ const m=e.data; if(m?.type==='scanResult'
           }
         });
       }
+=======
+import * as vscode from 'vscode'; import * as path from 'path'; import { spawn } from 'child_process';
+export function activate(context: vscode.ExtensionContext) {
+  const cmd = vscode.commands.registerCommand('odavlStudio.openPanel', () => {
+    const panel = vscode.window.createWebviewPanel('odavlStudio','ODAVL Studio',vscode.ViewColumn.One,{ enableScripts:true });
+    panel.webview.html = `<!doctype html><html><body style="font-family:sans-serif;padding:16px"><h1>ODAVL Studio</h1><p>Scan + Heal (remove-unused)</p><div style="display:flex;gap:8px;margin-bottom:8px"><button id="scan">Scan</button><label><input type="checkbox" id="apply"> Apply</label><button id="heal">Heal</button></div><pre id="out" style="background:#111;color:#eee;padding:8px;border-radius:6px;min-height:120px;white-space:pre-wrap"></pre><script>const vscode=acquireVsCodeApi();const out=document.getElementById('out');const log=(t,d)=>{out.textContent+="\\n# "+t+"\\n"+(typeof d==="string"?d:JSON.stringify(d,null,2))+"\\n";};document.getElementById('scan').addEventListener('click',()=>vscode.postMessage({type:'scan'}));document.getElementById('heal').addEventListener('click',()=>{const apply=document.getElementById('apply').checked;vscode.postMessage({type:'heal',apply});});window.addEventListener('message',e=>{const m=e.data;if(m?.type==='scanResult')log('Scan',m.data);if(m?.type==='healResult')log('Heal',m.data);if(m?.type==='error')log('Error',m.error);});</script></body></html>`;
+    panel.webview.onDidReceiveMessage(async msg => {
+      try {
+        const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath; if(!root){ panel.webview.postMessage({type:'error',error:'No workspace root'}); return; }
+        if (msg?.type === 'scan') {
+          const payload = { tool:'odavl', action:'scan', pass:true, metrics:{eslint:17,typeErrors:0}, generatedAt:new Date().toISOString() };
+          panel.webview.postMessage({ type:'scanResult', data: payload });
+        } else if (msg?.type === 'heal') {
+          const cli = path.join(root,'apps','cli','dist','index.js');
+          const args = [cli,'heal','--recipe','remove-unused']; if (msg.apply) args.push('--apply');
+          const child = spawn(process.execPath, args, { cwd: root, shell: process.platform==='win32' });
+          let out='', err=''; child.stdout.on('data',d=>out+=d.toString()); child.stderr.on('data',d=>err+=d.toString());
+          child.on('close',()=>{ try{ const json=JSON.parse(out.trim()); panel.webview.postMessage({type:'healResult',data:json}); }catch{ panel.webview.postMessage({type:'healResult',data:{pass:false,raw:out,stderr:err}});} });
+        }
+      } catch (e:any) { panel.webview.postMessage({type:'error',error:String(e?.message||e)}); }
+>>>>>>> 2f52f83be1f7d671946596a5de23440ec38f1014
     }, undefined, context.subscriptions);
   });
   context.subscriptions.push(cmd);

--- a/apps/vscode-ext/tsconfig.json
+++ b/apps/vscode-ext/tsconfig.json
@@ -1,1 +1,5 @@
+<<<<<<< HEAD
 {"compilerOptions":{"target":"ES2020","module":"commonjs","moduleResolution":"node","strict":true,"skipLibCheck":true,"outDir":"dist","rootDir":"src","esModuleInterop":true,"lib":["ES2020"]},"include":["src"]}
+=======
+{"compilerOptions":{"target":"ES2020","module":"commonjs","moduleResolution":"node","strict":true,"skipLibCheck":true,"outDir":"dist","rootDir":"src","esModuleInterop":true,"lib":["ES2020"],"types":["node","vscode"]},"include":["src"]}
+>>>>>>> 2f52f83be1f7d671946596a5de23440ec38f1014

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1151 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      turbo:
+        specifier: ^2.5.6
+        version: 2.5.6
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+
+  apps/cli:
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.17
+
+  apps/vscode-ext:
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.17
+      '@types/vscode':
+        specifier: ^1.85.0
+        version: 1.104.0
+
+  examples/golden-repo:
+    dependencies:
+      lodash:
+        specifier: 4.17.15
+        version: 4.17.15
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.36.0
+        version: 9.36.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.44.0
+        version: 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0)(typescript@5.9.2))(eslint@9.36.0)(typescript@5.9.2)
+      '@typescript-eslint/parser':
+        specifier: ^8.44.0
+        version: 8.44.0(eslint@9.36.0)(typescript@5.9.2)
+      eslint:
+        specifier: ^9.36.0
+        version: 9.36.0
+      eslint-plugin-unused-imports:
+        specifier: ^4.2.0
+        version: 4.2.0(@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0)(typescript@5.9.2))(eslint@9.36.0)(typescript@5.9.2))(eslint@9.36.0)
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+
+  packages/codemods: {}
+
+  packages/core: {}
+
+  packages/policy: {}
+
+  packages/reporters: {}
+
+packages:
+
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.1':
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.0':
+    resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.3.1':
+    resolution: {integrity: sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.15.2':
+    resolution: {integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.36.0':
+    resolution: {integrity: sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.6':
+    resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.3.5':
+    resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@20.19.17':
+    resolution: {integrity: sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==}
+
+  '@types/vscode@1.104.0':
+    resolution: {integrity: sha512-0KwoU2rZ2ecsTGFxo4K1+f+AErRsYW0fsp6A0zufzGuhyczc2IoKqYqcwXidKXmy2u8YB2GsYsOtiI9Izx3Tig==}
+
+  '@typescript-eslint/eslint-plugin@8.44.0':
+    resolution: {integrity: sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.44.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/parser@8.44.0':
+    resolution: {integrity: sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.44.0':
+    resolution: {integrity: sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/scope-manager@8.44.0':
+    resolution: {integrity: sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.44.0':
+    resolution: {integrity: sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.44.0':
+    resolution: {integrity: sha512-9cwsoSxJ8Sak67Be/hD2RNt/fsqmWnNE1iHohG8lxqLSNY8xNfyY7wloo5zpW3Nu9hxVgURevqfcH6vvKCt6yg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/types@8.44.0':
+    resolution: {integrity: sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.44.0':
+    resolution: {integrity: sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.44.0':
+    resolution: {integrity: sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.44.0':
+    resolution: {integrity: sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-plugin-unused-imports@4.2.0:
+    resolution: {integrity: sha512-hLbJ2/wnjKq4kGA9AUaExVFIbNzyxYdVo49QZmKCnhk5pc9wcYRbfgLHvWJ8tnsdcseGhoUAddm9gn/lt+d74w==}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
+      eslint: ^9.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.36.0:
+    resolution: {integrity: sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.15:
+    resolution: {integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-api-utils@2.1.0:
+    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  turbo-darwin-64@2.5.6:
+    resolution: {integrity: sha512-3C1xEdo4aFwMJAPvtlPqz1Sw/+cddWIOmsalHFMrsqqydcptwBfu26WW2cDm3u93bUzMbBJ8k3zNKFqxJ9ei2A==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@2.5.6:
+    resolution: {integrity: sha512-LyiG+rD7JhMfYwLqB6k3LZQtYn8CQQUePbpA8mF/hMLPAekXdJo1g0bUPw8RZLwQXUIU/3BU7tXENvhSGz5DPA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@2.5.6:
+    resolution: {integrity: sha512-GOcUTT0xiT/pSnHL4YD6Yr3HreUhU8pUcGqcI2ksIF9b2/r/kRHwGFcsHgpG3+vtZF/kwsP0MV8FTlTObxsYIA==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@2.5.6:
+    resolution: {integrity: sha512-10Tm15bruJEA3m0V7iZcnQBpObGBcOgUcO+sY7/2vk1bweW34LMhkWi8svjV9iDF68+KJDThnYDlYE/bc7/zzQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@2.5.6:
+    resolution: {integrity: sha512-FyRsVpgaj76It0ludwZsNN40ytHN+17E4PFJyeliBEbxrGTc5BexlXVpufB7XlAaoaZVxbS6KT8RofLfDRyEPg==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@2.5.6:
+    resolution: {integrity: sha512-j/tWu8cMeQ7HPpKri6jvKtyXg9K1gRyhdK4tKrrchH8GNHscPX/F71zax58yYtLRWTiK04zNzPcUJuoS0+v/+Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.5.6:
+    resolution: {integrity: sha512-gxToHmi9oTBNB05UjUsrWf0OyN5ZXtD0apOarC1KIx232Vp3WimRNy3810QzeNSgyD5rsaIDXlxlbnOzlouo+w==}
+    hasBin: true
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.36.0)':
+    dependencies:
+      eslint: 9.36.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/config-array@0.21.0':
+    dependencies:
+      '@eslint/object-schema': 2.1.6
+      debug: 4.4.3
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.3.1': {}
+
+  '@eslint/core@0.15.2':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.36.0': {}
+
+  '@eslint/object-schema@2.1.6': {}
+
+  '@eslint/plugin-kit@0.3.5':
+    dependencies:
+      '@eslint/core': 0.15.2
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.7':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.19.1
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@20.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/vscode@1.104.0': {}
+
+  '@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0)(typescript@5.9.2))(eslint@9.36.0)(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 8.44.0(eslint@9.36.0)(typescript@5.9.2)
+      '@typescript-eslint/scope-manager': 8.44.0
+      '@typescript-eslint/type-utils': 8.44.0(eslint@9.36.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.44.0(eslint@9.36.0)(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.44.0
+      eslint: 9.36.0
+      graphemer: 1.4.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.44.0(eslint@9.36.0)(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.44.0
+      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.44.0
+      debug: 4.4.3
+      eslint: 9.36.0
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.44.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.44.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.44.0
+      debug: 4.4.3
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.44.0':
+    dependencies:
+      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/visitor-keys': 8.44.0
+
+  '@typescript-eslint/tsconfig-utils@8.44.0(typescript@5.9.2)':
+    dependencies:
+      typescript: 5.9.2
+
+  '@typescript-eslint/type-utils@8.44.0(eslint@9.36.0)(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.44.0(eslint@9.36.0)(typescript@5.9.2)
+      debug: 4.4.3
+      eslint: 9.36.0
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.44.0': {}
+
+  '@typescript-eslint/typescript-estree@8.44.0(typescript@5.9.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.44.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.44.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/visitor-keys': 8.44.0
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.44.0(eslint@9.36.0)(typescript@5.9.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0)
+      '@typescript-eslint/scope-manager': 8.44.0
+      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.9.2)
+      eslint: 9.36.0
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.44.0':
+    dependencies:
+      '@typescript-eslint/types': 8.44.0
+      eslint-visitor-keys: 4.2.1
+
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  callsites@3.1.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-unused-imports@4.2.0(@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0)(typescript@5.9.2))(eslint@9.36.0)(typescript@5.9.2))(eslint@9.36.0):
+    dependencies:
+      eslint: 9.36.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0)(typescript@5.9.2))(eslint@9.36.0)(typescript@5.9.2)
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.36.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.21.0
+      '@eslint/config-helpers': 0.3.1
+      '@eslint/core': 0.15.2
+      '@eslint/eslintrc': 3.3.1
+      '@eslint/js': 9.36.0
+      '@eslint/plugin-kit': 0.3.5
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.19.1:
+    dependencies:
+      reusify: 1.1.0
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+
+  flatted@3.3.3: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  graphemer@1.4.0: {}
+
+  has-flag@4.0.0: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  lodash@4.17.15: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  ms@2.1.3: {}
+
+  natural-compare@1.4.0: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  picomatch@2.3.1: {}
+
+  prelude-ls@1.2.1: {}
+
+  prettier@3.6.2: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  resolve-from@4.0.0: {}
+
+  reusify@1.1.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  semver@7.7.2: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  ts-api-utils@2.1.0(typescript@5.9.2):
+    dependencies:
+      typescript: 5.9.2
+
+  turbo-darwin-64@2.5.6:
+    optional: true
+
+  turbo-darwin-arm64@2.5.6:
+    optional: true
+
+  turbo-linux-64@2.5.6:
+    optional: true
+
+  turbo-linux-arm64@2.5.6:
+    optional: true
+
+  turbo-windows-64@2.5.6:
+    optional: true
+
+  turbo-windows-arm64@2.5.6:
+    optional: true
+
+  turbo@2.5.6:
+    optionalDependencies:
+      turbo-darwin-64: 2.5.6
+      turbo-darwin-arm64: 2.5.6
+      turbo-linux-64: 2.5.6
+      turbo-linux-arm64: 2.5.6
+      turbo-windows-64: 2.5.6
+      turbo-windows-arm64: 2.5.6
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript@5.9.2: {}
+
+  undici-types@6.21.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  yocto-queue@0.1.0: {}

--- a/reports/ci-root-causes-20250920-030633.md
+++ b/reports/ci-root-causes-20250920-030633.md
@@ -1,0 +1,221 @@
+### CI Failure Diagnosis — PR #4
+
+**Branch:** odavl/heal-wire-20250920
+
+#### Recent Runs
+- Run 17873127914: VS Code: wire Heal to real CLI (remove-unused) — completed/failure at 2025-09-20T00:59:20Z
+- Run 17873127708: resolve: ci.yml & README after merging main — completed/failure at 2025-09-20T00:59:19Z
+
+#### Log snippet: ci-run-17873127914.log (first 120 lines)
+
+build (18)	Set up job	2025-09-20T00:59:22.7419830Z Current runner version: '2.328.0'
+build (18)	Set up job	2025-09-20T00:59:22.7454010Z ##[group]Runner Image Provisioner
+build (18)	Set up job	2025-09-20T00:59:22.7455191Z Hosted Compute Agent
+build (18)	Set up job	2025-09-20T00:59:22.7456160Z Version: 20250829.383
+build (18)	Set up job	2025-09-20T00:59:22.7457323Z Commit: 27cb235aab5b0e52e153a26cd86b4742e89dac5d
+build (18)	Set up job	2025-09-20T00:59:22.7458636Z Build Date: 2025-08-29T13:48:48Z
+build (18)	Set up job	2025-09-20T00:59:22.7459582Z ##[endgroup]
+build (18)	Set up job	2025-09-20T00:59:22.7460618Z ##[group]Operating System
+build (18)	Set up job	2025-09-20T00:59:22.7461798Z Ubuntu
+build (18)	Set up job	2025-09-20T00:59:22.7462646Z 24.04.3
+build (18)	Set up job	2025-09-20T00:59:22.7463538Z LTS
+build (18)	Set up job	2025-09-20T00:59:22.7464400Z ##[endgroup]
+build (18)	Set up job	2025-09-20T00:59:22.7465269Z ##[group]Runner Image
+build (18)	Set up job	2025-09-20T00:59:22.7466105Z Image: ubuntu-24.04
+build (18)	Set up job	2025-09-20T00:59:22.7467118Z Version: 20250907.24.1
+build (18)	Set up job	2025-09-20T00:59:22.7468918Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250907.24/images/ubuntu/Ubuntu2404-Readme.md
+build (18)	Set up job	2025-09-20T00:59:22.7471729Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250907.24
+build (18)	Set up job	2025-09-20T00:59:22.7473651Z ##[endgroup]
+build (18)	Set up job	2025-09-20T00:59:22.7475523Z ##[group]GITHUB_TOKEN Permissions
+build (18)	Set up job	2025-09-20T00:59:22.7478310Z Contents: read
+build (18)	Set up job	2025-09-20T00:59:22.7479255Z Metadata: read
+build (18)	Set up job	2025-09-20T00:59:22.7480128Z Packages: read
+build (18)	Set up job	2025-09-20T00:59:22.7481217Z ##[endgroup]
+build (18)	Set up job	2025-09-20T00:59:22.7484631Z Secret source: Actions
+build (18)	Set up job	2025-09-20T00:59:22.7486054Z Prepare workflow directory
+build (18)	Set up job	2025-09-20T00:59:22.8475863Z Prepare all required actions
+build (18)	Set up job	2025-09-20T00:59:22.8530750Z Getting action download info
+build (18)	Set up job	2025-09-20T00:59:23.1368572Z Download action repository 'actions/checkout@v4' (SHA:08eba0b27e820071cde6df949e0beb9ba4906955)
+build (18)	Set up job	2025-09-20T00:59:23.2091750Z Download action repository 'pnpm/action-setup@v4' (SHA:a7487c7e89a18df4991f7f222e4898a00d66ddda)
+build (18)	Set up job	2025-09-20T00:59:23.5050868Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+build (18)	Set up job	2025-09-20T00:59:23.8422398Z Complete job name: build (18)
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9168357Z ##[group]Run actions/checkout@v4
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9169323Z with:
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9169776Z   repository: Monawlo812/odavl_studio
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9170694Z   token: ***
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9171365Z   ssh-strict: true
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9171833Z   ssh-user: git
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9172290Z   persist-credentials: true
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9172829Z   clean: true
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9173274Z   sparse-checkout-cone-mode: true
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9173881Z   fetch-depth: 1
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9174299Z   fetch-tags: false
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9174744Z   show-progress: true
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9175194Z   lfs: false
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9175580Z   submodules: false
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9176056Z   set-safe-directory: true
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:23.9176843Z ##[endgroup]
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0241393Z Syncing repository: Monawlo812/odavl_studio
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0243868Z ##[group]Getting Git version info
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0245039Z Working directory is '/home/runner/work/odavl_studio/odavl_studio'
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0246412Z [command]/usr/bin/git version
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0247133Z git version 2.46.0
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0248198Z ##[endgroup]
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0249370Z Temporarily overriding HOME='/home/runner/work/_temp/a7af8c3b-fa78-4b8d-86e0-a2e4d6e0b66e' before making global git config changes
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0251522Z Adding repository directory to the temporary git global config as a safe directory
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0253226Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/odavl_studio/odavl_studio
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0254453Z ##[group]Determining the checkout info
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0255596Z ##[endgroup]
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0256740Z ##[group]Git LFS checkout info
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0257858Z ##[endgroup]
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0258976Z ##[group]Checking out the ref
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0260236Z [command]/usr/bin/git checkout --progress --force -B odavl/heal-wire-20250920 refs/remotes/origin/odavl/heal-wire-20250920
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0297646Z Reset branch 'odavl/heal-wire-20250920'
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0298657Z Your branch is up to date with 'origin/odavl/heal-wire-20250920'.
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0308686Z ##[endgroup]
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0398806Z [command]/usr/bin/git log --format='%H' -n 1
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:24.0421066Z 260fd77a2d9cff6ad53f4a09edc1af4cc6d47c5c
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:24.0496576Z ##[group]Run pnpm/action-setup@v4
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:24.0497542Z with:
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:24.0498012Z   version: 9
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:24.0498501Z ##[endgroup]
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:24.1039787Z Downloading PNPM 9.0.0
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:24.3987598Z PNPM 9.0.0 has been cached at /opt/hostedtoolcache/pnpm/9.0.0/x64
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:24.3988579Z PNPM 9.0.0 has been installed at /opt/hostedtoolcache/pnpm/9.0.0/x64/bin/pnpm
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.3995966Z ##[group]Run actions/setup-node@v4
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.3996932Z with:
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.3997483Z   node-version: 18
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.3998157Z   cache: pnpm
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.3998616Z ##[endgroup]
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.6067017Z Found in cache @ /opt/hostedtoolcache/node/18.20.4/x64
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.6320522Z ##[group]Environment details
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.6321787Z node: v18.20.4
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.6322599Z npm: 10.7.0
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.6323429Z yarn: 1.22.19
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.6324169Z ##[endgroup]
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.6355896Z ##[group]Cache hit
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.6357162Z Cache not found for input keys: linux-pnpm-6e59cbf7c2c4a062b8e51b04c71b8c8c6e6e66cee3b87b6cea1e59fab38bd68b, linux-pnpm-
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:24.6359127Z ##[endgroup]
+build (18)	Install	2025-09-20T00:59:24.6634014Z ##[group]Run pnpm install
+build (18)	Install	2025-09-20T00:59:24.6635090Z ##[endgroup]
+
+<details><summary>Root-cause candidates (grep)</summary>
+
+68:build (18)	Install	2025-09-20T00:59:24.8045529Z ##[error]  ENOENT: no such file or directory, scandir 'odavl_studio'
+
+</details>
+
+#### Log snippet: ci-run-17873127708.log (first 120 lines)
+
+build (18)	Set up job	2025-09-20T00:59:21.5926845Z Current runner version: '2.328.0'
+build (18)	Set up job	2025-09-20T00:59:21.5961025Z ##[group]Runner Image Provisioner
+build (18)	Set up job	2025-09-20T00:59:21.5962206Z Hosted Compute Agent
+build (18)	Set up job	2025-09-20T00:59:21.5963175Z Version: 20250829.383
+build (18)	Set up job	2025-09-20T00:59:21.5964338Z Commit: 27cb235aab5b0e52e153a26cd86b4742e89dac5d
+build (18)	Set up job	2025-09-20T00:59:21.5965651Z Build Date: 2025-08-29T13:48:48Z
+build (18)	Set up job	2025-09-20T00:59:21.5966597Z ##[endgroup]
+build (18)	Set up job	2025-09-20T00:59:21.5967633Z ##[group]Operating System
+build (18)	Set up job	2025-09-20T00:59:21.5968813Z Ubuntu
+build (18)	Set up job	2025-09-20T00:59:21.5969661Z 24.04.3
+build (18)	Set up job	2025-09-20T00:59:21.5970553Z LTS
+build (18)	Set up job	2025-09-20T00:59:21.5971415Z ##[endgroup]
+build (18)	Set up job	2025-09-20T00:59:21.5972284Z ##[group]Runner Image
+build (18)	Set up job	2025-09-20T00:59:21.5973120Z Image: ubuntu-24.04
+build (18)	Set up job	2025-09-20T00:59:21.5974133Z Version: 20250907.24.1
+build (18)	Set up job	2025-09-20T00:59:21.5975933Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250907.24/images/ubuntu/Ubuntu2404-Readme.md
+build (18)	Set up job	2025-09-20T00:59:21.5978744Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250907.24
+build (18)	Set up job	2025-09-20T00:59:21.5980666Z ##[endgroup]
+build (18)	Set up job	2025-09-20T00:59:21.5982538Z ##[group]GITHUB_TOKEN Permissions
+build (18)	Set up job	2025-09-20T00:59:21.5985325Z Contents: read
+build (18)	Set up job	2025-09-20T00:59:21.5986270Z Metadata: read
+build (18)	Set up job	2025-09-20T00:59:21.5987143Z Packages: read
+build (18)	Set up job	2025-09-20T00:59:21.5988232Z ##[endgroup]
+build (18)	Set up job	2025-09-20T00:59:21.5991646Z Secret source: Actions
+build (18)	Set up job	2025-09-20T00:59:21.5993069Z Prepare workflow directory
+build (18)	Set up job	2025-09-20T00:59:21.6982878Z Prepare all required actions
+build (18)	Set up job	2025-09-20T00:59:21.7037765Z Getting action download info
+build (18)	Set up job	2025-09-20T00:59:21.9875587Z Download action repository 'actions/checkout@v4' (SHA:08eba0b27e820071cde6df949e0beb9ba4906955)
+build (18)	Set up job	2025-09-20T00:59:22.0598765Z Download action repository 'pnpm/action-setup@v4' (SHA:a7487c7e89a18df4991f7f222e4898a00d66ddda)
+build (18)	Set up job	2025-09-20T00:59:22.3557883Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+build (18)	Set up job	2025-09-20T00:59:22.6929413Z Complete job name: build (18)
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7675372Z ##[group]Run actions/checkout@v4
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7676338Z with:
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7676791Z   repository: Monawlo812/odavl_studio
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7677709Z   token: ***
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7678380Z   ssh-strict: true
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7678848Z   ssh-user: git
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7679305Z   persist-credentials: true
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7679844Z   clean: true
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7680289Z   sparse-checkout-cone-mode: true
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7680896Z   fetch-depth: 1
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7681314Z   fetch-tags: false
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7681759Z   show-progress: true
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7682209Z   lfs: false
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7682595Z   submodules: false
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7683071Z   set-safe-directory: true
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.7683858Z ##[endgroup]
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8748408Z Syncing repository: Monawlo812/odavl_studio
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8750883Z ##[group]Getting Git version info
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8752054Z Working directory is '/home/runner/work/odavl_studio/odavl_studio'
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8753427Z [command]/usr/bin/git version
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8754148Z git version 2.46.0
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8755213Z ##[endgroup]
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8756385Z Temporarily overriding HOME='/home/runner/work/_temp/49bf3c74-a9f8-4dba-a72e-c8a63c9b9dbc' before making global git config changes
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8758537Z Adding repository directory to the temporary git global config as a safe directory
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8760241Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/odavl_studio/odavl_studio
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8761468Z ##[group]Determining the checkout info
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8762611Z ##[endgroup]
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8763755Z ##[group]Git LFS checkout info
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8764873Z ##[endgroup]
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8765991Z ##[group]Checking out the ref
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8767251Z [command]/usr/bin/git checkout --progress --force -B odavl/heal-wire-20250920 refs/remotes/origin/odavl/heal-wire-20250920
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8804661Z Reset branch 'odavl/heal-wire-20250920'
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8805672Z Your branch is up to date with 'origin/odavl/heal-wire-20250920'.
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8815701Z ##[endgroup]
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8905821Z [command]/usr/bin/git log --format='%H' -n 1
+build (18)	Run actions/checkout@v4	2025-09-20T00:59:22.8928081Z 260fd77a2d9cff6ad53f4a09edc1af4cc6d47c5c
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:22.9003591Z ##[group]Run pnpm/action-setup@v4
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:22.9004557Z with:
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:22.9005027Z   version: 9
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:22.9005516Z ##[endgroup]
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:22.9546802Z Downloading PNPM 9.0.0
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:23.2494613Z PNPM 9.0.0 has been cached at /opt/hostedtoolcache/pnpm/9.0.0/x64
+build (18)	Run pnpm/action-setup@v4	2025-09-20T00:59:23.2495594Z PNPM 9.0.0 has been installed at /opt/hostedtoolcache/pnpm/9.0.0/x64/bin/pnpm
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.2502981Z ##[group]Run actions/setup-node@v4
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.2503947Z with:
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.2504498Z   node-version: 18
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.2505172Z   cache: pnpm
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.2505631Z ##[endgroup]
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.4574032Z Found in cache @ /opt/hostedtoolcache/node/18.20.4/x64
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.4827537Z ##[group]Environment details
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.4828802Z node: v18.20.4
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.4829614Z npm: 10.7.0
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.4830444Z yarn: 1.22.19
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.4831184Z ##[endgroup]
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.4862911Z ##[group]Cache hit
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.4864177Z Cache not found for input keys: linux-pnpm-6e59cbf7c2c4a062b8e51b04c71b8c8c6e6e66cee3b87b6cea1e59fab38bd68b, linux-pnpm-
+build (18)	Run actions/setup-node@v4	2025-09-20T00:59:23.4866142Z ##[endgroup]
+build (18)	Install	2025-09-20T00:59:23.5141029Z ##[group]Run pnpm install
+build (18)	Install	2025-09-20T00:59:23.5142105Z ##[endgroup]
+
+<details><summary>Root-cause candidates (grep)</summary>
+
+68:build (18)	Install	2025-09-20T00:59:23.6552544Z ##[error]  ENOENT: no such file or directory, scandir 'odavl_studio'
+
+</details>
+
+## Root Cause Analysis
+
+🔴 **Critical Issue Identified**: 
+
+**Error**: `ENOENT: no such file or directory, scandir 'odavl_studio'`
+
+**Problem**: The CI workflow configuration has `working-directory: odavl_studio` in `defaults.run`, but this creates an invalid path:
+- GitHub Actions checkouts to: `/home/runner/work/odavl_studio/odavl_studio` 
+- CI tries to cd to: `/home/runner/work/odavl_studio/odavl_studio/odavl_studio`
+- Result: **Directory not found**
+
+**Solution**: Remove the `defaults.run.working-directory: odavl_studio` from `.github/workflows/ci.yml` since GitHub Actions already places us in the correct repository root.
+
+**Files to Fix**:
+- `.github/workflows/ci.yml` - Remove lines 6-8 (defaults block)

--- a/reports/health-20250920-025429.md
+++ b/reports/health-20250920-025429.md
@@ -1,0 +1,142 @@
+# ODAVL Studio — Full Health Report
+**Generated**: September 20, 2025 02:54:29
+
+## Repo & Branch Status
+- **Current Branch**: `odavl/heal-wire-20250920` (PR #4)
+- **Base Branch**: `odavl/bootstrap-20250919` (default)
+- **Merge Base**: `aca411722d9c052427fdcdf8d1d978b1e16ebef6`
+- **Repository**: `Monawlo812/odavl_studio`
+
+## Tool Versions
+- **Node.js**: v22.19.0
+- **pnpm**: 10.17.0
+- **Git**: git version 2.50.1.windows.1
+- **TypeScript**: Version 5.9.2 (via CLI package)
+- **ESLint**: v9.36.0
+
+## CI Workflow Analysis
+
+### Base Branch Workflow
+❌ **No CI workflow found** on base branch `odavl/bootstrap-20250919`
+- Path `.github/workflows/ci.yml` does not exist on base
+
+### PR Branch Workflow
+✅ **CI workflow present** on PR branch `odavl/heal-wire-20250920`
+```yaml
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - '**'
+defaults:
+  run:
+    working-directory: odavl_studio
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, 20]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+```
+
+## PR #4 Status & Checks
+
+### Metadata
+- **URL**: https://github.com/Monawlo812/odavl_studio/pull/4
+- **Base**: `main` → **Head**: `odavl/heal-wire-20250920`
+- **Merge State**: `DIRTY` 
+- **Mergeable**: `CONFLICTING` ⚠️
+- **Files Changed**: 8 files
+
+### Status Checks
+❌ **build (18)**: COMPLETED (FAILURE) 
+❌ **build (20)**: COMPLETED (CANCELLED)
+
+### Changed Files
+```
+.github/workflows/ci.yml (+9, -4)
+README.md (+3, -0)
+apps/cli/package.json (+1, -1)
+apps/cli/src/index.ts (+62, -0)
+apps/cli/tsconfig.json (+1, -1)
+apps/vscode-ext/package.json (+1, -1)
+apps/vscode-ext/src/extension.ts (+15, -38)
+apps/vscode-ext/tsconfig.json (+1, -1)
+```
+
+## Latest CI Logs (Run: 17872816086)
+
+**Key Log Excerpt**:
+```
+Working directory is '/home/runner/work/odavl_studio/odavl_studio'
+```
+
+⚠️ **Critical Issue Identified**: CI workflow sets `working-directory: odavl_studio` but GitHub Actions checkouts to `/home/runner/work/odavl_studio/odavl_studio`, creating a **nested directory problem**.
+
+The CI is trying to execute commands in:
+- Expected: `/home/runner/work/odavl_studio/odavl_studio/odavl_studio/` 
+- Actual: `/home/runner/work/odavl_studio/odavl_studio/`
+
+## Merge-Conflict Candidates
+
+### File Intersection Analysis
+**Files changed in both PR and main since merge base**:
+- `.github/workflows/ci.yml` ⚠️
+
+**Risk Assessment**: **HIGH** - The CI workflow file has diverged between main and PR branch.
+
+## Workspace Build/Lint/Type-Check Summary
+
+### Build Results
+✅ **CLI Build**: Successful (`@odavl/cli`)
+✅ **VS Code Extension Build**: Successful (`@odavl/vscode-ext`)
+✅ **ESLint (golden-repo)**: No violations found
+❌ **Type-check**: No type-check scripts configured in workspace packages
+
+### Dependency Status
+✅ **pnpm install**: Lockfile up to date, completed in 930ms
+
+## Policy & Hygiene Findings
+
+### Policy Files
+✅ **Policy Configuration**: Present
+- `.odavl.policy.yml` ✅
+- `.odavl/gates.yml` ✅
+
+### Lockfile Analysis
+⚠️ **Banned Lockfiles**: 
+- `yarn.lock`: Not found ✅
+- `package-lock.json`: **Found** ❌ (Should use pnpm-lock.yaml only)
+
+## Recommendations
+
+### 🔴 Critical (Must Fix)
+1. **Fix CI Working Directory**: Remove `defaults.run.working-directory: odavl_studio` from `.github/workflows/ci.yml`
+   - GitHub Actions already checkouts to the repo root
+   - Current setting creates invalid nested path structure
+
+2. **Resolve Merge Conflicts**: 
+   - `.github/workflows/ci.yml` has conflicts with main branch
+   - Consider rebasing PR onto latest main
+
+3. **Remove Banned Lockfile**:
+   - Delete `package-lock.json` from repository root
+   - Ensure only `pnpm-lock.yaml` is used
+
+### 🟡 High Priority
+4. **Add Type-Check Scripts**: Configure `type-check` scripts in workspace packages
+5. **Base Branch CI**: Add CI workflow to default branch for consistency
+
+### 🟢 Improvements
+6. **CI Matrix**: Consider if Node 18 is still needed (Node 20+ recommended)
+7. **Workspace Scripts**: Add common development scripts to root package.json
+
+---
+**Status**: PR #4 has critical CI configuration issues preventing successful merge.
+**Next Action**: Fix working-directory setting and resolve merge conflicts.


### PR DESCRIPTION
What:
- Adds 'Open PR' UI (title + dry-run) and wires it to CLI: \odavl pr open --explain [--dry-run]\.
- Captures JSON result and renders it in the panel.

Why:
- Enable creating PRs from Studio with clear Explain context and safe dry-run.

Verify:
- Build: \pnpm --filter @odavl/vscode-ext run build\`n- Run extension: 'Run and Debug  Run ODAVL Studio Extension'
- In panel: set 'Dry-run'  and a title, click 'Open PR'  expect JSON with wouldOpen:true.

Risk:
- Low; UI + spawn of existing CLI only.