### PR TITLE
Register alt ODAVL CI Doctor (placeholder)

### DIFF
--- a/.github/workflows/odavl-ci-doctor.yml
+++ b/.github/workflows/odavl-ci-doctor.yml
@@ -1,0 +1,15 @@
+name: ODAVL CI Doctor
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: read
+  checks: write
+  security-events: write
+  pull-requests: write
+jobs:
+  registered:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Doctor workflow registered (placeholder)."


### PR DESCRIPTION
### **User description**
Adds a minimal workflow_dispatch-only placeholder to register the workflow on default.


___

### **PR Type**
Other


___

### **Description**
- Add placeholder GitHub Actions workflow for ODAVL CI Doctor

- Configure workflow with manual trigger and basic permissions

- Include minimal job to register workflow on default branch


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions"] --> B["ODAVL CI Doctor Workflow"]
  B --> C["Manual Trigger Only"]
  B --> D["Placeholder Job"]
  D --> E["Echo Registration Message"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>odavl-ci-doctor.yml</strong><dd><code>Add ODAVL CI Doctor workflow placeholder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/odavl-ci-doctor.yml

<ul><li>Create new GitHub Actions workflow file<br> <li> Configure workflow_dispatch trigger for manual execution<br> <li> Set permissions for contents, actions, checks, security-events, and <br>pull-requests<br> <li> Add placeholder job that outputs registration message</ul>


</details>


  </td>
  <td><a href="https://github.com/Monawlo812/odavl_studio/pull/44/files#diff-f8c801af7397a3e5bc9a8e32156faab54e08fea98151eb0408d69aef9eb4c3cd">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

